### PR TITLE
implement -f flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,19 +33,31 @@ fn main() -> std::io::Result<()> {
                 .takes_value(true)
                 .help("Change to <dir> before doing anything"),
         )
+        .arg(
+            Arg::with_name("file")
+                .short("f")
+                .takes_value(true)
+                .help("Use <file> as a makefile"),
+        )
         .get_matches();
 
     if let Some(dir) = matches.value_of("dir") {
         env::set_current_dir(Path::new(dir))?;
     }
 
-    let mut file = File::open("GNUmakefile");
-    if file.is_err() {
-        file = File::open("makefile");
-    }
-    if file.is_err() {
-        file = File::open("Makefile");
-    }
+    let mut file = if let Some(file) = matches.value_of("file") {
+        File::open(file)
+    } else {
+        let mut file = File::open("GNUmakefile");
+        if file.is_err() {
+            file = File::open("makefile");
+        }
+        if file.is_err() {
+            file = File::open("Makefile");
+        }
+        file
+    };
+
     if let Ok(mut file) = file {
         let mut content = String::new();
         file.read_to_string(&mut content)?;


### PR DESCRIPTION
Implements -f flag. didn't do longopt because there are two (--file= and --makefile=)and i don't know how clap handles that.