### PR TITLE
Switch to argparse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,113 +3,14 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "argparse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "bitflags"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "clap"
-version = "2.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
-dependencies = [
- "libc",
-]
+checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "lc-make"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "argparse",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
+argparse = "0.2.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> std::io::Result<()> {
         "Use <file> as the Makefile instead of Makefile",
     );
     ap.refer(&mut target)
-        .add_argument("target", argparse::ParseOption, "Target to build");
+        .add_argument("TARGET", argparse::ParseOption, "TARGET to build");
     ap.refer(&mut silent).add_option(
         &["--silent", "-s", "--quiet"],
         argparse::StoreTrue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,56 +1,58 @@
-use clap::{App, Arg};
+use argparse::ArgumentParser;
 
-use std::env;
 use std::fs::File;
-use std::path::Path;
+use std::path::PathBuf;
 
 use lc_make::loader::MakeFileLoader;
 
 fn main() -> std::io::Result<()> {
-    let matches = App::new("LC Make")
-        .version("0.1.0")
-        .author("Ray Redondo <rdrpenguin04@gmail.com>")
-        .arg(
-            Arg::with_name("dir")
-                .short("C")
-                .long("directory")
-                .takes_value(true)
-                .help("Change to <dir> before doing anything"),
-        )
-        .arg(
-            Arg::with_name("file")
-                .short("f")
-                .takes_value(true)
-                .help("Use <file> as a makefile"),
-        )
-        .arg(
-            Arg::with_name("silent")
-                .short("s")
-                .help("Don't echo recipes"),
-        )
-        .arg(Arg::with_name("target"))
-        .get_matches();
-
-    // handle -C flag
-    if let Some(dir) = matches.value_of("dir") {
-        env::set_current_dir(Path::new(dir))?;
+    let mut dir = None::<PathBuf>;
+    let mut file = None::<PathBuf>;
+    let mut silent = false;
+    let mut target = None::<String>;
+    let mut ap = ArgumentParser::new();
+    ap.refer(&mut dir).add_option(
+        &["-C"],
+        argparse::StoreOption,
+        "Change to the given directory before doing anything else",
+    );
+    ap.refer(&mut file).add_option(
+        &["-f"],
+        argparse::StoreOption,
+        "Use <file> as the Makefile instead of Makefile",
+    );
+    ap.refer(&mut target)
+        .add_argument("target", argparse::ParseOption, "Target to build");
+    ap.refer(&mut silent).add_option(
+        &["--silent", "-s", "--quiet"],
+        argparse::StoreTrue,
+        "Prevents make from outputting anything",
+    );
+    ap.parse_args_or_exit();
+    drop(ap);
+    if let Some(dir) = dir {
+        std::env::set_current_dir(dir)?;
     }
-
-    // if the user specified a makefile then use that file
-    // otherwise try and find one from a list of defaults
-    let file = if let Some(file) = matches.value_of("file") {
-        Some(File::open(file))
+    let file = if let Some(file) = file {
+        File::open(file)
     } else {
         let defaults = vec!["GNUmakefile", "makefile", "Makefile"];
 
-        defaults.into_iter().map(File::open).find(Result::is_ok)
+        defaults
+            .into_iter()
+            .map(File::open)
+            .find(Result::is_ok)
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, "Cannot find makefile")
+            })
+            .and_then(|s| s)
     };
 
     // create a new makefile loader
     let mut loader = MakeFileLoader::new();
 
     // if we have a valid file then load the makefile's contents
-    if let Some(Ok(mut file)) = file {
+    if let Ok(mut file) = file {
         loader.load(&mut file)?;
     }
 
@@ -58,8 +60,7 @@ fn main() -> std::io::Result<()> {
     let makefile = loader.finalise();
 
     // perform the build
-    let silent = matches.is_present("silent");
-    if let Some(target) = matches.value_of("target") {
+    if let Some(target) = target {
         // don't be silent for debugging purposes
         makefile.build_target(target, silent);
     } else {


### PR DESCRIPTION
Switching to `argparse` from `clap` reduces the total number of transitive dependencies to one, making vendoring significantly easier.